### PR TITLE
feat(dependency_graph): Add caching and progress tracking to import finder

### DIFF
--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/__init__.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/__init__.py
@@ -78,7 +78,7 @@ class TreeSitterDependencyGraphGenerator(BaseDependencyGraphGenerator):
         for (
             importer_file_path,
             importer_module_name,
-        ), import_symbol_nodes in import_map.items():
+        ), import_symbol_nodes in tqdm(import_map.items(), desc="Resolving imports"):
             for import_symbol_node in import_symbol_nodes:
                 resolved = []
                 try:

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/import_finder.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/import_finder.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from pathlib import Path
 from textwrap import dedent
 
@@ -243,12 +244,14 @@ class ImportFinder:
         captures = query.captures(tree.root_node)
         return [node for node, captured in captures if captured == capture_name]
 
+    @lru_cache(maxsize=256)
     def find_imports(
         self,
         code: str,
     ) -> list[TS_Node]:
         return self._query_and_captures(code, FIND_IMPORT_QUERY[self.language])
 
+    @lru_cache(maxsize=256)
     def find_module_name(self, file_path: Path) -> str | None:
         """
         Find the name of the module of the current file.


### PR DESCRIPTION
- Adds `lru_cache` decorator to `find_imports` and `find_module_name` methods for performance optimization.
- Introduces progress bar (`tqdm`) when iterating over `import_map` items during import resolution.