### PR TITLE
refactor(types): Update type annotations for consistency and clarity

### DIFF
--- a/repo_specific_semantic_graph/dependency_graph/__init__.py
+++ b/repo_specific_semantic_graph/dependency_graph/__init__.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 from pathlib import Path
 from textwrap import dedent
+from typing import Union, Optional
 
 import networkx as nx
 from ipysigma import Sigma
@@ -24,9 +23,9 @@ logger = setup_logger()
 
 
 def construct_dependency_graph(
-    repo: Repository | PathLike,
+    repo: Union[Repository, PathLike],
     dependency_graph_generator: GraphGeneratorType,
-    language: Language | None = None,
+    language: Optional[Language] = None,
 ) -> DependencyGraph:
     if isinstance(repo, str) or isinstance(repo, Path) or isinstance(repo, VirtualPath):
         if language is None:

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/__init__.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/__init__.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 import enum
 from abc import ABC, abstractmethod, ABCMeta
 from functools import wraps
+from typing import Tuple
 
 from dependency_graph.dependency_graph import DependencyGraph
 from dependency_graph.models import PathLike
@@ -45,7 +44,7 @@ class BaseDependencyGraphGeneratorMeta(ABCMeta):
 
 
 class BaseDependencyGraphGenerator(ABC, metaclass=BaseDependencyGraphGeneratorMeta):
-    supported_languages: tuple[Language] = ()
+    supported_languages: Tuple[Language] = ()
 
     def _validate_language(self, language: Language):
         if language not in self.supported_languages:

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/jedi_generator.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/jedi_generator.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
 import re
 import sys
 import traceback
+from typing import Dict, Tuple, Optional, List
 
 import jedi
 from jedi.api.classes import Name, BaseName, Completion
@@ -33,7 +32,7 @@ from dependency_graph.utils.log import setup_logger
 logger = setup_logger()
 
 # Mapping from jedi api type to node type
-_JEDI_API_TYPES_dict: dict[str, NodeType | None] = {
+_JEDI_API_TYPES_dict: Optional[Dict[str, NodeType]] = {
     "module": NodeType.MODULE,
     "class": NodeType.CLASS,
     "instance": NodeType.VARIABLE,
@@ -48,11 +47,11 @@ _JEDI_API_TYPES_dict: dict[str, NodeType | None] = {
 
 
 class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
-    supported_languages: tuple[Language] = (Language.Python,)
+    supported_languages: Tuple[Language] = (Language.Python,)
 
     def _convert_name_pos_to_location(
-        self, name: Name, node_type: NodeType | None = None
-    ) -> Location | None:
+        self, name: Name, node_type: Optional[NodeType] = None
+    ) -> Optional[Location]:
         """helper function for creating location"""
         if name is None:
             return None
@@ -103,9 +102,9 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
         from_type: NodeType,
         to_name: Name,
         to_type: NodeType,
-        edge_name: (
-            Name | None
-        ),  # Edge name can be None as not all relation have a location
+        edge_name: Optional[
+            Name
+        ],  # Edge name can be None as not all relation have a location
         edge_relation: EdgeRelation,
         inverse_edge_relation: EdgeRelation,
     ):
@@ -124,7 +123,7 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_parent_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
         for name in all_names:
@@ -172,7 +171,7 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_import_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
         for name in all_names:
@@ -223,7 +222,7 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_call_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
         for name in all_names:
@@ -261,7 +260,7 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_instantiate_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
         for name in all_names:
@@ -349,7 +348,7 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_def_use_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
         for name in all_names:
@@ -390,10 +389,10 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_class_hierarchy_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
-        def get_parent_classes_with_columns(class_definition: str) -> dict[str, int]:
+        def get_parent_classes_with_columns(class_definition: str) -> Dict[str, int]:
             """
             Get the parent classes and their columns in the class definition header
             e.g.
@@ -467,7 +466,7 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_method_override_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
         for name in all_names:
@@ -512,7 +511,7 @@ class JediDependencyGraphGenerator(BaseDependencyGraphGenerator):
     def _extract_field_use_relation(
         self,
         script: jedi.Script,
-        all_names: list[Name],
+        all_names: List[Name],
         D: DependencyGraph,
     ):
         for name in all_names:

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/__init__.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/__init__.py
@@ -1,9 +1,7 @@
-from __future__ import annotations
-
 import traceback
 from collections import defaultdict
 from pathlib import Path
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Union
 
 from tqdm import tqdm
 
@@ -86,9 +84,9 @@ class TreeSitterDependencyGraphGenerator(BaseDependencyGraphGenerator):
         D = DependencyGraph(repo.repo_path, repo.language)
         module_map: Dict[str, List[Path]] = defaultdict(list)
         # The key is (file_path, class_name)
-        import_map: dict[tuple[Path, str], list[ParseTreeInfo] | list[RegexInfo]] = (
-            defaultdict(list)
-        )
+        import_map: Dict[
+            Tuple[Path, str], Union[List[ParseTreeInfo], List[RegexInfo]]
+        ] = defaultdict(list)
 
         finder = ImportFinder(repo.language)
         resolver = ImportResolver(repo)

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/import_finder.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/import_finder.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 import re
 from functools import lru_cache
 from pathlib import Path
 from textwrap import dedent
+from typing import List, Union, Optional
 
 from tree_sitter import Parser, Language as TS_Language, Tree
 
@@ -251,7 +250,7 @@ class ImportFinder:
 
     def _query_and_captures(
         self, code: str, query: str, capture_name="import_name"
-    ) -> list[ParseTreeInfo]:
+    ) -> List[ParseTreeInfo]:
         """
         Query the Tree-sitter language and get the nodes that match the query
         :param code: The code to be parsed
@@ -277,7 +276,7 @@ class ImportFinder:
         del tree
         return info_list
 
-    def _regex_find_imports(self, code: str, pattern: str) -> list[RegexInfo]:
+    def _regex_find_imports(self, code: str, pattern: str) -> List[RegexInfo]:
         matches = []
         for match in re.finditer(pattern, code, re.MULTILINE):
             module_name = match.group(1)
@@ -304,7 +303,7 @@ class ImportFinder:
     def find_imports(
         self,
         code: str,
-    ) -> list[RegexInfo] | list[ParseTreeInfo]:
+    ) -> Union[List[RegexInfo], List[ParseTreeInfo]]:
         if self.language in self.languages_using_regex:
             return self._regex_find_imports(
                 code, REGEX_FIND_IMPORT_PATTERN[self.language]
@@ -313,7 +312,7 @@ class ImportFinder:
             return self._query_and_captures(code, FIND_IMPORT_QUERY[self.language])
 
     @lru_cache(maxsize=256)
-    def find_module_name(self, file_path: Path) -> str | None:
+    def find_module_name(self, file_path: Path) -> Optional[str]:
         """
         Find the name of the module of the current file.
         This term is broad enough to encompass the different ways in which these languages organize and reference code units

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/info.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/info.py
@@ -1,19 +1,18 @@
-from __future__ import annotations
-
 from dataclasses import dataclass
+from typing import Tuple, Optional
 
 
 @dataclass
 class ParseTreeInfo:
-    start_point: tuple[int, int]
-    end_point: tuple[int, int]
+    start_point: Tuple[int, int]
+    end_point: Tuple[int, int]
     text: str
     type: str
-    parent: ParseTreeInfo | None = None
+    parent: Optional["ParseTreeInfo"] = None
 
 
 @dataclass
 class RegexInfo:
-    start_point: tuple[int, int]
-    end_point: tuple[int, int]
+    start_point: Tuple[int, int]
+    end_point: Tuple[int, int]
     text: str

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/python_resolver.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/python_resolver.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from pathlib import Path
+from typing import Optional
 
 from importlab.import_finder import is_builtin
 from importlab.resolve import (
@@ -27,7 +26,7 @@ class Resolver:
                 return file
         return None
 
-    def resolve_import(self, item) -> Path | None:
+    def resolve_import(self, item) -> Optional[Path]:
         """Simulate how Python resolves imports.
 
         Returns the filename of the source file Python would load

--- a/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/resolve_import.py
+++ b/repo_specific_semantic_graph/dependency_graph/graph_generator/tree_sitter_generator/resolve_import.py
@@ -1,10 +1,8 @@
-from __future__ import annotations
-
 import os
 import re
 import sys
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Union, Optional
 
 from importlab.parsepy import ImportStatement
 from importlab.resolve import ImportException
@@ -55,10 +53,10 @@ class ImportResolver:
 
     def resolve_import(
         self,
-        import_symbol_node: ParseTreeInfo | RegexInfo,
-        module_map: dict[str, list[Path]],
+        import_symbol_node: Union[ParseTreeInfo, RegexInfo],
+        module_map: Dict[str, List[Path]],
         importer_file_path: Path,
-    ) -> list[Path]:
+    ) -> List[Path]:
         resolved_path_list = []
         if isinstance(import_symbol_node, RegexInfo):
             assert (
@@ -139,10 +137,10 @@ class ImportResolver:
     def resolve_ts_js_import(
         self,
         import_symbol_node: ParseTreeInfo,
-        module_map: dict[str, list[Path]],
+        module_map: Dict[str, List[Path]],
         importer_file_path: Path,
-    ) -> list[Path]:
-        def _search_file(search_path: Path, module_name: str) -> list[Path]:
+    ) -> List[Path]:
+        def _search_file(search_path: Path, module_name: str) -> List[Path]:
             result_path = []
             for ext in extension_list:
                 if (search_path / f"{module_name}{ext}").exists():
@@ -193,7 +191,7 @@ class ImportResolver:
         self,
         import_symbol_node: ParseTreeInfo,
         importer_file_path: Path,
-    ) -> list[Path]:
+    ) -> List[Path]:
         def analyze_import_statement(
             import_statement: str, is_from_import: bool = None
         ) -> List[Tuple[str, str, str, bool]]:
@@ -298,7 +296,7 @@ class ImportResolver:
         self,
         import_symbol_node: ParseTreeInfo,
         importer_file_path: Path,
-    ) -> list[Path]:
+    ) -> List[Path]:
         import_symbol_name = import_symbol_node.text
         # Strip double and single quote
         import_symbol_name = import_symbol_name.strip('"').strip("'")
@@ -317,7 +315,7 @@ class ImportResolver:
         self,
         import_symbol_node: ParseTreeInfo,
         importer_file_path: Path,
-    ) -> list[Path]:
+    ) -> List[Path]:
         import_symbol_name = import_symbol_node.text
         # Strip double and single quote
         import_symbol_name = import_symbol_name.strip('"').strip("'")
@@ -346,7 +344,7 @@ class ImportResolver:
         self,
         import_symbol_node: ParseTreeInfo,
         importer_file_path: Path,
-    ) -> list[Path]:
+    ) -> List[Path]:
 
         import_symbol_name = import_symbol_node.text
         # Strip double quote and angle bracket
@@ -401,8 +399,8 @@ class ImportResolver:
 
         return result_path
 
-    def resolve_go_import(self, import_symbol_node: ParseTreeInfo) -> list[Path]:
-        def parse_go_mod(go_mod_path: Path) -> tuple[str, dict[str, Path]]:
+    def resolve_go_import(self, import_symbol_node: ParseTreeInfo) -> List[Path]:
+        def parse_go_mod(go_mod_path: Path) -> Tuple[str, Dict[str, Path]]:
             """
             Parses the go.mod file and returns the module path and replacements.
             :param go_mod_path: The path to the go.mod file.
@@ -480,7 +478,7 @@ class ImportResolver:
 
     def resolve_swift_import(
         self, import_symbol_node: ParseTreeInfo, importer_file_path: Path
-    ) -> list[Path]:
+    ) -> List[Path]:
         import_symbol_name = import_symbol_node.text
         if "." in import_symbol_name:
             # Handle individual declarations importing such as `import kind module.symbol`
@@ -526,12 +524,12 @@ class ImportResolver:
 
     def resolve_rust_import(
         self, import_symbol_node: ParseTreeInfo, importer_file_path: Path
-    ) -> list[Path]:
+    ) -> List[Path]:
         def find_import_path(
             project_root: Path,
             file: Path,
-            module_path: list[str],
-        ) -> Path | None:
+            module_path: List[str],
+        ) -> Optional[Path]:
             """
             Given the project root, the file containing the import, and the module path,
             heuristically find the corresponding file path for the imported module.
@@ -679,8 +677,10 @@ class ImportResolver:
             return [imported_file] if imported_file else []
 
     def resolve_lua_import(
-        self, import_symbol_node: ParseTreeInfo | RegexInfo, importer_file_path: Path
-    ) -> list[Path]:
+        self,
+        import_symbol_node: Union[ParseTreeInfo, RegexInfo],
+        importer_file_path: Path,
+    ) -> List[Path]:
         import_symbol_name = import_symbol_node.text
 
         import_symbol_name = import_symbol_name.strip('"').strip("'")
@@ -707,8 +707,10 @@ class ImportResolver:
         return []
 
     def resolve_bash_import(
-        self, import_symbol_node: ParseTreeInfo | RegexInfo, importer_file_path: Path
-    ) -> list[Path]:
+        self,
+        import_symbol_node: Union[ParseTreeInfo, RegexInfo],
+        importer_file_path: Path,
+    ) -> List[Path]:
         import_symbol_name = import_symbol_node.text
         import_path = self._Path(import_symbol_name)
         if import_path.is_relative_to(self.repo.repo_path) and import_path.exists():
@@ -723,8 +725,10 @@ class ImportResolver:
         return []
 
     def resolve_r_import(
-        self, import_symbol_node: ParseTreeInfo | RegexInfo, importer_file_path: Path
-    ) -> list[Path]:
+        self,
+        import_symbol_node: Union[ParseTreeInfo, RegexInfo],
+        importer_file_path: Path,
+    ) -> List[Path]:
         import_symbol_name = import_symbol_node.text
         import_symbol_name = import_symbol_name.strip('"').strip("'")
 

--- a/repo_specific_semantic_graph/dependency_graph/models/graph_data.py
+++ b/repo_specific_semantic_graph/dependency_graph/models/graph_data.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import enum
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -81,7 +79,7 @@ class Location:
     def __hash__(self) -> int:
         return hash(self.__str__())
 
-    def get_text(self) -> str | None:
+    def get_text(self) -> Optional[str]:
         # TODO should leverage the FileNode.content
         if self.file_path is None:
             return None
@@ -131,12 +129,12 @@ class Node:
     def __hash__(self) -> int:
         return hash(self.__str__())
 
-    def get_text(self) -> str | None:
+    def get_text(self) -> Optional[str]:
         return self.location.get_text()
 
     def get_stub(
         self, language: Language, include_comments: bool = False
-    ) -> str | None:
+    ) -> Optional[str]:
         if language == Language.Python:
             from dependency_graph.utils.mypy_stub import generate_python_stub
 
@@ -191,7 +189,7 @@ class Edge:
     def __hash__(self) -> int:
         return hash(self.__str__())
 
-    def get_text(self) -> str | None:
+    def get_text(self) -> Optional[str]:
         return self.location.get_text()
 
     def get_inverse_edge(self) -> "Edge":

--- a/repo_specific_semantic_graph/dependency_graph/models/repository.py
+++ b/repo_specific_semantic_graph/dependency_graph/models/repository.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Dict, Tuple, Set
 
 from dependency_graph.models import PathLike
 from dependency_graph.models.file_node import FileNode
@@ -19,7 +17,7 @@ class Repository:
     repo_path: Path = None
     language: Language
 
-    code_file_extensions: dict[Language, tuple[str]] = {
+    code_file_extensions: Dict[Language, Tuple[str]] = {
         Language.CSharp: (".cs", ".csx"),
         Language.Python: (".py", ".pyi"),
         Language.Java: (".java",),
@@ -61,7 +59,7 @@ class Repository:
                 f"Language {self.language} is not supported to get code files"
             )
 
-        self._files: set[FileNode] = set()
+        self._files: Set[FileNode] = set()
 
         # try:
         #     self._git_repo = Repo(repo_path)
@@ -70,7 +68,7 @@ class Repository:
         #     pass
 
     @property
-    def files(self) -> set[FileNode]:
+    def files(self) -> Set[FileNode]:
         if self._files:
             return self._files
 

--- a/repo_specific_semantic_graph/dependency_graph/models/virtual_fs/virtual_repository.py
+++ b/repo_specific_semantic_graph/dependency_graph/models/virtual_fs/virtual_repository.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from collections import namedtuple
-from typing import Iterable
+from typing import Iterable, List, Set
 
 from fs.memoryfs import MemoryFS
 
@@ -20,7 +18,7 @@ class VirtualRepository(Repository):
         self,
         repo_path: PathLike,
         language: Language,
-        virtual_files: list[VirtualFile],  # Use the named tuple for typing
+        virtual_files: List[VirtualFile],  # Use the named tuple for typing
     ):
         self.fs = MemoryFS()
         # Make sure the repo path is absolute
@@ -39,8 +37,8 @@ class VirtualRepository(Repository):
         super().__init__(self.repo_path, language)
 
     @property
-    def files(self) -> set[VirtualFileNode]:
-        files: set[VirtualFileNode] = set(
+    def files(self) -> Set[VirtualFileNode]:
+        files: Set[VirtualFileNode] = set(
             [VirtualFileNode(file_path) for file_path in self._all_file_paths]
         )
         return files

--- a/repo_specific_semantic_graph/dependency_graph/utils/intervals.py
+++ b/repo_specific_semantic_graph/dependency_graph/utils/intervals.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
-
-from typing import Iterable, Any
+from typing import Iterable, Any, Tuple, Optional
 
 
 def find_innermost_interval(
-    intervals: Iterable[tuple[int, int, Any]], index: int
-) -> tuple[int, int, Any] | None:
+    intervals: Iterable[Tuple[int, int, Any]], index: int
+) -> Optional[Tuple[int, int, Any]]:
     """
     Finds the innermost interval that contains the specified index.
 

--- a/repo_specific_semantic_graph/dependency_graph/utils/read_file.py
+++ b/repo_specific_semantic_graph/dependency_graph/utils/read_file.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
-
 from pathlib import Path
+from typing import Tuple
 
 import chardet
 
@@ -34,7 +33,7 @@ def detect_file_encoding(file_path: Path) -> str:
     return encoding
 
 
-def read_file_with_encodings(file_path: Path, encodings: tuple[str]) -> tuple[str, str]:
+def read_file_with_encodings(file_path: Path, encodings: Tuple[str]) -> Tuple[str, str]:
     """Attempt to read a file using various encodings, return content if successful"""
     for encoding in encodings:
         try:

--- a/repo_specific_semantic_graph/dependency_graph/utils/text.py
+++ b/repo_specific_semantic_graph/dependency_graph/utils/text.py
@@ -1,9 +1,9 @@
-from __future__ import annotations
+from typing import Tuple
 
 
 def slice_text_around(
     text: str, start_line: int, start_column: int, end_line: int, end_column: int
-) -> tuple[str, str, str]:
+) -> Tuple[str, str, str]:
     """
     Slice the text around the specified portion of the text.
     :param text: The text to slice

--- a/repo_specific_semantic_graph/dependency_graph/utils/tree_sitter_stub.py
+++ b/repo_specific_semantic_graph/dependency_graph/utils/tree_sitter_stub.py
@@ -2,7 +2,10 @@ from textwrap import dedent
 
 from tree_sitter import Language, Parser, Tree, Node
 
-from dependency_graph.graph_generator.tree_sitter_generator.load_lib import get_builtin_lib_path, TS_LIB_PATH
+from dependency_graph.graph_generator.tree_sitter_generator.load_lib import (
+    get_builtin_lib_path,
+    TS_LIB_PATH,
+)
 
 SPECIAL_CHAR = b" "
 


### PR DESCRIPTION
- Updated type annotations to use `Tuple` and `Optional` from the `typing` module.
- Removed unnecessary `from __future__ import annotations` imports.
- Ensured consistent use of type annotations across functions and methods.