### PR TITLE
feat(dependency_graph): Add support for merging graphs with same nodes

### DIFF
--- a/repo_specific_semantic_graph/dependency_graph/dependency_graph.py
+++ b/repo_specific_semantic_graph/dependency_graph/dependency_graph.py
@@ -2,7 +2,7 @@ import json
 import sys
 from functools import lru_cache
 from pathlib import Path
-from typing import Iterable, Callable, Optional, Tuple, List
+from typing import Iterable, Callable, Optional, Tuple, List, Set
 
 import networkx as nx
 

--- a/repo_specific_semantic_graph/dependency_graph/models/graph_data.py
+++ b/repo_specific_semantic_graph/dependency_graph/models/graph_data.py
@@ -79,6 +79,9 @@ class Location:
     def __hash__(self) -> int:
         return hash(self.__str__())
 
+    def __eq__(self, other):
+        return hash(self) == hash(other)
+
     def get_text(self) -> Optional[str]:
         if self.file_path is None:
             return None
@@ -94,7 +97,10 @@ class Location:
 
     file_path: Optional[Path] = field(
         default=None,
-        metadata=config(encoder=lambda v: str(v), decoder=lambda v: Path(v)),
+        metadata=config(
+            encoder=lambda v: str(v),
+            decoder=lambda v: v if isinstance(v, Path) else Path(v),
+        ),
     )
     """The file path"""
     start_line: Optional[int] = None
@@ -127,6 +133,9 @@ class Node:
 
     def __hash__(self) -> int:
         return hash(self.__str__())
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
     def get_text(self) -> Optional[str]:
         return self.location.get_text()
@@ -187,6 +196,9 @@ class Edge:
 
     def __hash__(self) -> int:
         return hash(self.__str__())
+
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
     def get_text(self) -> Optional[str]:
         return self.location.get_text()


### PR DESCRIPTION
feat(dependency_graph): Add support for merging graphs with same nodes

This change introduces the ability to merge two `DependencyGraph` instances that share common nodes. Additionally, it includes necessary updates to handle equality checks and hashing for graph data models.

- Added `MemoryFS` and `VirtualPath` imports for testing purposes.
- Implemented a new test case `test_merge_graph_with_same_node` to verify the merge functionality.
- Updated `graph_data.py` to include `__eq__` methods based on hashes for better comparison handling.